### PR TITLE
fix: Update Prettier version from 3.5.3 to 3.6.2 in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,10 +23,10 @@ importers:
     devDependencies:
       '@trivago/prettier-plugin-sort-imports':
         specifier: 5.2.2
-        version: 5.2.2(prettier@3.5.3)
+        version: 5.2.2(prettier@3.6.2)
       prettier:
-        specifier: 3.5.3
-        version: 3.5.3
+        specifier: 3.6.2
+        version: 3.6.2
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
@@ -1538,8 +1538,8 @@ packages:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
     engines: {node: ^14.15.0 || >=16.0.0}
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -2613,7 +2613,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.5.3)':
+  '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.6.2)':
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/parser': 7.27.7
@@ -2621,7 +2621,7 @@ snapshots:
       '@babel/types': 7.27.7
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
-      prettier: 3.5.3
+      prettier: 3.6.2
     transitivePeerDependencies:
       - supports-color
 
@@ -3961,10 +3961,10 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       '@astrojs/compiler': 2.12.2
-      prettier: 3.5.3
+      prettier: 3.6.2
       sass-formatter: 0.7.9
 
-  prettier@3.5.3: {}
+  prettier@3.6.2: {}
 
   prismjs@1.30.0: {}
 


### PR DESCRIPTION
This pull request updates the `prettier` dependency from version `3.5.3` to `3.6.2` across multiple sections of the `pnpm-lock.yaml` file to ensure compatibility and leverage the latest features and fixes.

Dependency updates:

* Updated the `prettier` version from `3.5.3` to `3.6.2` in the `devDependencies` section. (`pnpm-lock.yaml`, [pnpm-lock.yamlL26-R29](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL26-R29))
* Updated the resolution and integrity hash for `prettier` to version `3.6.2` in the `packages` section. (`pnpm-lock.yaml`, [pnpm-lock.yamlL1541-R1542](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1541-R1542))

Snapshot updates:

* Updated the `@trivago/prettier-plugin-sort-imports` dependency to use `prettier@3.6.2` instead of `3.5.3`. (`pnpm-lock.yaml`, [pnpm-lock.yamlL2616-R2624](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2616-R2624))
* Updated the `prettier-plugin-astro` dependency to use `prettier@3.6.2` instead of `3.5.3`. Also updated the direct snapshot entry for `prettier` to version `3.6.2`. (`pnpm-lock.yaml`, [pnpm-lock.yamlL3964-R3967](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3964-R3967))